### PR TITLE
Wrap CHR bank number on MMC3

### DIFF
--- a/lib/optcarrot/mapper/mmc3.rb
+++ b/lib/optcarrot/mapper/mmc3.rb
@@ -60,6 +60,7 @@ module Optcarrot
     def update_chr(addr, bank)
       return if @chr_ram
       idx = addr / 0x400
+      bank %= @chr_banks.size
       return if @chr_bank_mapping[idx] == bank
       addr ^= 0x1000 if @chr_bank_swap
       @ppu.update(0)


### PR DESCRIPTION
Some game sets CHR bank number out of its range.
When it is occurred, CHR ROM is broken
and exception will be occurred in `PPU#load_sprite`