### PR TITLE
Mirror RAM

### DIFF
--- a/lib/optcarrot/cpu.rb
+++ b/lib/optcarrot/cpu.rb
@@ -86,11 +86,11 @@ module Optcarrot
     end
 
     def peek_ram(addr)
-      @ram[addr - 0x0800]
+      @ram[addr & (0x0800 - 1)]
     end
 
     def poke_ram(addr, data)
-      @ram[addr - 0x0800] = data
+      @ram[addr & (0x0800 - 1)] = data
     end
 
     def peek_nop(addr)


### PR DESCRIPTION
CPU RAM 0x0800-0x1FFF are mapped 0x0000-0x07FF repeatedly.