### PR TITLE
Fix CHR BANK change for MMC1

### DIFF
--- a/lib/optcarrot/mapper/mmc1.rb
+++ b/lib/optcarrot/mapper/mmc1.rb
@@ -5,7 +5,7 @@ module Optcarrot
 
     NMT_MODE = [:second, :first, :vertical, :horizontal]
     PRG_MODE = [:conseq, :conseq, :fix_first, :fix_last]
-    CHR_MODE = [:noconseq, :conseq]
+    CHR_MODE = [:conseq, :noconseq]
 
     def init
       @nmt_mode = @prg_mode = @chr_mode = nil
@@ -42,7 +42,11 @@ module Optcarrot
             update_prg(prg_mode, @prg_bank, @chr_bank_0)
             update_chr(chr_mode, @chr_bank_0, @chr_bank_1)
           when 1 # change chr_bank_0
+            # update_prg might modify @chr_bank_0 and prevent updating chr bank,
+            # so keep current value.
+            bak_chr_bank_0 = @chr_bank_0
             update_prg(@prg_mode, @prg_bank, @shift)
+            @chr_bank_0 = bak_chr_bank_0
             update_chr(@chr_mode, @shift, @chr_bank_1)
           when 2 # change chr_bank_1
             update_chr(@chr_mode, @chr_bank_0, @shift)


### PR DESCRIPTION
It seems `:conseq` and `:noconseq` are inverted for CHR ROM bank mode:

> CHR ROM bank mode (0: switch 8 KB at a time; 1: switch two separate 4 KB banks)
> http://wiki.nesdev.com/w/index.php/MMC1#Control_.28internal.2C_.248000-.249FFF.29

And calling `update_prg` might modify `@chr_bank_0` and prevent updating chr bank,
so keep its current value, and restore it to execute `update_chr`.
