### PR TITLE
Add a video driver using mplayer

### DIFF
--- a/lib/optcarrot/driver.rb
+++ b/lib/optcarrot/driver.rb
@@ -8,6 +8,7 @@ module Optcarrot
         png:   :PNGVideo,
         gif:   :GIFVideo,
         sixel: :SixelVideo,
+        mplayer: :MPlayerVideo,
         none:  :Video,
       },
       audio: {

--- a/lib/optcarrot/driver/misc.rb
+++ b/lib/optcarrot/driver/misc.rb
@@ -36,6 +36,9 @@ module Optcarrot
 
     SIZE = 1
     def show_fps(colors, fps, palette, &darken)
+      digits = fps > 100 ? 3 : 2
+      w = (3 + digits) * 4
+
       # darken the right-bottom corner for drawing FPS
       darken ||= lambda { |c|
         r = ((c >> 16) & 0xff) / 4
@@ -45,7 +48,7 @@ module Optcarrot
       }
 
       (223 - 6 * SIZE).upto(223) do |y|
-        (255 - 20 * SIZE).upto(255) do |x|
+        (255 - w * SIZE).upto(255) do |x|
           c = colors[idx = x + y * 256]
           colors[idx] = darken.call(c)
         end
@@ -54,20 +57,21 @@ module Optcarrot
       # decide fps color
       color =
         case
+        when fps >= 90 then palette[0x19] # green
         when fps >= 60 then palette[0x11] # blue
         when fps >= 55 then palette[0x28] # yellow
         else                palette[0x16] # red
         end
 
       # draw FPS
-      5.times do |i| # show "xxFPS"
-        bits = FONT[i <= 1 ? fps / 10**(1 - i) % 10 : i + 8]
+      (3 + digits).times do |i| # show "xxFPS"
+        bits = FONT[i < digits ? fps / 10**(digits - i - 1) % 10 : i - digits + 10]
         5.times do |y|
           3.times do |x|
             SIZE.times do |dy|
               SIZE.times do |dx|
                 if bits[x + y * 3] == 1
-                  colors[(224 + (y - 6) * SIZE + dy) * 256 + (256 + i * 4 + x - 20) * SIZE + dx] = color
+                  colors[(224 + (y - 6) * SIZE + dy) * 256 + (256 + i * 4 + x - w) * SIZE + dx] = color
                 end
               end
             end

--- a/lib/optcarrot/driver/misc.rb
+++ b/lib/optcarrot/driver/misc.rb
@@ -35,15 +35,19 @@ module Optcarrot
     EMPTY_ARRAY = []
 
     SIZE = 1
-    def show_fps(colors, fps, palette)
+    def show_fps(colors, fps, palette, &darken)
       # darken the right-bottom corner for drawing FPS
+      darken ||= lambda { |c|
+        r = ((c >> 16) & 0xff) / 4
+        g = ((c >>  8) & 0xff) / 4
+        b = ((c >>  0) & 0xff) / 4
+        (c & 0xff000000) | (r << 16) | (g << 8) | b
+      }
+
       (223 - 6 * SIZE).upto(223) do |y|
         (255 - 20 * SIZE).upto(255) do |x|
           c = colors[idx = x + y * 256]
-          r = ((c >> 16) & 0xff) / 4
-          g = ((c >>  8) & 0xff) / 4
-          b = ((c >>  0) & 0xff) / 4
-          colors[idx] = (c & 0xff000000) | (r << 16) | (g << 8) | b
+          colors[idx] = darken.call(c)
         end
       end
 

--- a/lib/optcarrot/driver/mplayer_video.rb
+++ b/lib/optcarrot/driver/mplayer_video.rb
@@ -1,0 +1,47 @@
+require_relative "misc"
+
+module Optcarrot
+  # Video output driver using mplayer
+  # Inspired from https://github.com/polmuz/pypy-image-demo/blob/master/io.py
+  class MPlayerVideo < Video
+    MAX_FPS = NES::FPS
+
+    def init
+      super
+      @mplayer = IO.popen('mplayer -really-quiet -noframedrop -vf scale - 2>/dev/null', 'wb')
+      @mplayer.puts("YUV4MPEG2 W#{WIDTH} H#{HEIGHT} F#{MAX_FPS}:1 Ip A#{TV_WIDTH}:#{WIDTH} C444")
+
+      @palette = @palette_rgb.map do |r, g, b|
+        # From https://en.wikipedia.org/wiki/YCbCr#JPEG_conversion
+        y  = ( 0.299    * r + 0.587    * g + 0.114    * b).to_i + 0
+        cb = (-0.168736 * r - 0.331264 * g + 0.5      * b).to_i + 128
+        cr = ( 0.5      * r - 0.418688 * g - 0.081312 * b).to_i + 128
+        [y, cr, cb]
+      end
+    end
+
+    def dispose
+      @mplayer.close
+    end
+
+    def tick(screen)
+      @mplayer.write "FRAME\n"
+
+      Driver.cutoff_overscan(screen)
+
+      if @conf.show_fps and @times.size >= 2
+        fps = (1.0 / (@times[-1] - @times[-2])).round
+        Driver.show_fps(screen, fps, @palette) { |y, cr, cb|
+          [y/4, cr, cb]
+        }
+      end
+
+      colors = screen.map { |a| a[0] } +
+               screen.map { |a| a[1] } +
+               screen.map { |a| a[2] }
+      @mplayer.write colors.pack('C*')
+
+      super
+    end
+  end
+end


### PR DESCRIPTION
* Also contains the 3-digits FPS change :)
* Thanks to the flexible usage of the palette, we can pre-compute once the palette in YCbCr and then directly use that as pixel values.
* This is not as fast on MRI as FFI, maybe `pack` is expensive?