### PR TITLE
Remove duplication in TruffleRuby's Docker image setup

### DIFF
--- a/tools/run-benchmark.rb
+++ b/tools/run-benchmark.rb
@@ -232,13 +232,13 @@ class TruffleRuby < DockerImage
   FROM = "fedora:26"
   graalvm_url = "http://www.oracle.com/technetwork/oracle-labs/program-languages/downloads/index.html"
   graalvm = "graalvm-0.30.2-linux-amd64-jdk8.tar.gz"
+  graalvm_dir = graalvm[/^graalvm-\d+(\.\d+)+/]
   RUN = [
     "echo && echo 'Download GraalVM from' && echo '#{graalvm_url}' && echo 'and move it to optcarrot/' &&" \
     "echo 'This step is manual currently (sorry)' && echo",
-    [:add, graalvm, "."],
-    "graalvm-0.30.2/bin/ruby -v"
+    [:add, graalvm, "."]
   ]
-  RUBY = "graalvm-0.30.2/bin/ruby"
+  RUBY = "#{graalvm_dir}/bin/ruby"
 end
 
 class Opal < DockerImage


### PR DESCRIPTION
* This makes it easier to update the GraalVM version.
* `ruby -v` is already done when running the benchmark.