### PR TITLE
Add benchmark.yml for benchmark_driver.gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "benchmark_driver", ">= 0.10.16", group: :development
 gem "ffi"
 gem "rake", group: [:development, :test]
 gem "rubocop", group: :development

--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,0 +1,9 @@
+# Benchmark definition for benchmark_driver.gem
+type: command_stdout
+name: optcarrot
+command: -r./tools/shim.rb bin/optcarrot --benchmark examples/Lan_Master.nes
+metrics_type:
+  unit: fps
+stdout_to_metrics: |
+  match = stdout.match(/^fps: (?<fps>\d+\.\d+)$/)
+  Float(match[:fps])


### PR DESCRIPTION
## Usage
Having this YAML file is convenient for comparing performance among multiple Ruby binaries.

```
$ benchmark-driver benchmark.yml --rbenv '2.0.0-p648;2.6.0-preview2;2.6.0-preview2,--jit' --repeat-count 4 --verbose 1
2.0.0-p648: ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-linux]
2.6.0-preview2: ruby 2.6.0preview2 (2018-05-31 trunk 63539) [x86_64-linux]
2.6.0-preview2,--jit: ruby 2.6.0preview2 (2018-05-31 trunk 63539) +JIT [x86_64-linux]
Calculating -------------------------------------
                     2.0.0-p648  2.6.0-preview2  2.6.0-preview2,--jit
           optcarrot     35.952          51.988                72.874 fps

Comparison:
                        optcarrot
2.6.0-preview2,--jit:        72.9 fps
      2.6.0-preview2:        52.0 fps - 1.40x  slower
          2.0.0-p648:        36.0 fps - 2.03x  slower
```