### PR TITLE
Update benchmark_driver YAML for RubyBench

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "benchmark_driver", ">= 0.10.16", group: :development
+gem "benchmark_driver", ">= 0.11.0", group: :development
 gem "ffi"
 gem "rake", group: [:development, :test]
 gem "rubocop", group: :development

--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,9 +1,10 @@
-# Benchmark definition for benchmark_driver.gem
-type: command_stdout
-name: optcarrot
+type: ruby_stdout
+name: Optcarrot Lan_Master.nes
 command: -r./tools/shim.rb bin/optcarrot --benchmark examples/Lan_Master.nes
-metrics_type:
-  unit: fps
-stdout_to_metrics: |
-  match = stdout.match(/^fps: (?<fps>\d+\.\d+)$/)
-  Float(match[:fps])
+metrics:
+  Number of frames:
+    unit: fps
+    from_stdout: 'Float(stdout.match(/^fps: (?<fps>\d+\.\d+)$/)[:fps])'
+environment:
+  Checksum:
+    from_stdout: 'Integer(stdout.match(/^checksum: (?<checksum>\d+)$/)[:checksum])'


### PR DESCRIPTION
To use benchmark_driver.gem to collect metrics for RubyBench, I want to modify the benchmark.yml added in https://github.com/mame/optcarrot/pull/20 to:

* Extract checksum from stdout and pass it as environment
* Use the same labels as https://rubybench.org/ruby/ruby/commits?result_type=Optcarrot%20Lan_Master.nes

`type: ruby_stdout` was newly added to achieve such purposes at v0.11.0.