### PR TITLE
Fix MMC1 mirroring for single pages

### DIFF
--- a/lib/optcarrot/mapper/mmc1.rb
+++ b/lib/optcarrot/mapper/mmc1.rb
@@ -3,7 +3,7 @@ module Optcarrot
   class MMC1 < ROM
     MAPPER_DB[0x01] = self
 
-    NMT_MODE = [:second, :first, :vertical, :horizontal]
+    NMT_MODE = [:first, :second, :vertical, :horizontal]
     PRG_MODE = [:conseq, :conseq, :fix_first, :fix_last]
     CHR_MODE = [:conseq, :noconseq]
 


### PR DESCRIPTION
It seems that MMC1 mirroring for single pages are inverted:
<https://wiki.nesdev.com/w/index.php/MMC1#Control_.28internal.2C_.248000-.249FFF.29>
> 0: one-screen, lower bank;
> 1: one-screen, upper bank;

I've tested the behavior on Ys1.
