### PR TITLE
Show the fps history up to 3000 frames in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See [`doc/bonus.md`](doc/bonus.md) for advanced usage.
 ## Benchmark example
 
 ![benchmark chart](doc/benchmark-summary.png)
+![fps history chart (up to 3000 frames)](doc/fps-history-3000.png)
 
 See [`doc/benchmark.md`](doc/benchmark.md) for the measurement condition and some other charts.
 


### PR DESCRIPTION
* The first 180 frames tell a partial story: they would last only
  3 seconds at 60 FPS while an actual game will run far longer.

I think many/most people will only see the README and miss the benchmark.md link or not click it.
Also benchmark.md contains a lot more information, which seems not so relevant for most readers.
Since OptCarrot is principally a benchmark I think it makes total sense to show the most relevant charts directly in the README.