### PR TITLE
Use FFI::Pointer#write_bytes instead of #write_string

### DIFF
--- a/lib/optcarrot/driver/misc.rb
+++ b/lib/optcarrot/driver/misc.rb
@@ -117,7 +117,7 @@ module Optcarrot
       end
       dat = dat.bytes.map {|clr| palette[clr - 35] }
 
-      return width, height, pixels.write_string(dat.pack("V*"))
+      return width, height, pixels.write_bytes(dat.pack("V*"))
     end
   end
 end


### PR DESCRIPTION
* Since #write_string might append a final \0 byte in future FFI releases: https://github.com/ffi/ffi/pull/806