### PR TITLE
Add ability to print 95th percentile fps

### DIFF
--- a/lib/optcarrot/config.rb
+++ b/lib/optcarrot/config.rb
@@ -45,6 +45,7 @@ module Optcarrot
       },
       profiling: {
         print_fps: { type: :switch, desc: "print fps of last 10 frames", default: false },
+        print_p95fps: { type: :switch, desc: "print 95th percentile fps", default: false },
         print_fps_history: { type: :switch, desc: "print all fps values for each frame", default: false },
         print_video_checksum: { type: :switch, desc: "print checksum of the last video output", default: false },
         stackprof: { shortcut: "--stackprof-mode=cpu", aliases: :p },

--- a/lib/optcarrot/nes.rb
+++ b/lib/optcarrot/nes.rb
@@ -19,7 +19,7 @@ module Optcarrot
 
       @frame = 0
       @frame_target = @conf.frames == 0 ? nil : @conf.frames
-      @fps_history = [] if @conf.print_fps_history
+      @fps_history = [] if save_fps_history?
     end
 
     def inspect
@@ -48,7 +48,7 @@ module Optcarrot
 
       @input.tick(@frame, @pads)
       @fps = @video.tick(@ppu.output_pixels)
-      @fps_history << @fps if @conf.print_fps_history
+      @fps_history << @fps if save_fps_history?
       @audio.tick(@apu.output)
 
       @frame += 1
@@ -61,6 +61,9 @@ module Optcarrot
         if @conf.print_fps_history
           puts "frame,fps-history"
           @fps_history.each_with_index {|fps, frame| puts "#{ frame },#{ fps }" }
+        end
+        if @conf.print_p95fps
+          puts "p95 fps: #{@fps_history.sort[(@fps_history.length * 0.05).floor]}"
         end
         puts "fps: #{ @fps }" if @conf.print_fps
       end
@@ -88,6 +91,12 @@ module Optcarrot
       end
     ensure
       dispose
+    end
+
+    private
+
+    def save_fps_history?
+      @conf.print_fps_history || @conf.print_p95fps
     end
   end
 end


### PR DESCRIPTION
Add a `--print-p95fps` option to print the 95th percentile fps. This is useful for benchmarking the stutters including the effects of pauses in the garbage collector. The output looks like this:

```
p95 fps: 42.60319938664933
fps: 42.89933476147262
```