### PR TITLE
Fix problem that run-benchmark raise exception in specific docker tags.

### DIFF
--- a/tools/run-benchmark.rb
+++ b/tools/run-benchmark.rb
@@ -160,7 +160,7 @@ end
 ###############################################################################
 
 # https://github.com/rbenv/ruby-build/wiki
-MASTER_APT = %(
+MASTER_APT = %w(
   autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6
   libgdbm-dev libdb-dev git ruby
 )


### PR DESCRIPTION
An error occurs in executing run-benchmark.rb with specific docker tag identifiers, like master, mastermjit, etc.

```sh
❯ ruby tools/run-benchmark.rb master
+--------------+
| build master |
+--------------+
[+] Building 0.1s (2/2) FINISHED                                                                                                          
 => [internal] load build definition from Dockerfile.master                                                                          0.0s
 => => transferring dockerfile: 553B                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                    0.0s
 => => transferring context: 35B                                                                                                     0.0s
failed to solve with frontend dockerfile.v0: failed to create LLB definition: dockerfile parse error line 5: unknown instruction: AUTOCONF
tools/run-benchmark.rb:80:in `build': unhandled exception
        from tools/run-benchmark.rb:380:in `block in run_benchmark'
        from tools/run-benchmark.rb:406:in `block in each_target_image'
        from tools/run-benchmark.rb:404:in `each'
        from tools/run-benchmark.rb:404:in `each_target_image'
        from tools/run-benchmark.rb:378:in `run_benchmark'
        from tools/run-benchmark.rb:370:in `main'
        from tools/run-benchmark.rb:497:in `<main>'

```

An invalid dockerfile has generated as follows.
```
FROM ubuntu:20.04
WORKDIR /root
RUN apt-get update
RUN apt-get install -y 
  autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6
  libgdbm-dev libdb-dev git ruby
```

It seems inappropriate newline characters are included in %() for a definition of MASTER_APT.
(Rubocop may did that?)
This PR fix the problem.
