### PR TITLE
Cleanup PPU Fiber in NES#dipose

### DIFF
--- a/lib/optcarrot/config.rb
+++ b/lib/optcarrot/config.rb
@@ -102,7 +102,7 @@ module Optcarrot
     # command-line option parser
     class Parser
       def initialize(argv)
-        @argv = argv
+        @argv = argv.dup
         @options = DEFAULT_OPTIONS.dup
         parse_option until @argv.empty?
         error "ROM file is not given" unless @options[:romfile]

--- a/lib/optcarrot/nes.rb
+++ b/lib/optcarrot/nes.rb
@@ -74,6 +74,7 @@ module Optcarrot
       @audio.dispose
       @input.dispose
       @rom.save_battery
+      @ppu.dispose
     end
 
     def run


### PR DESCRIPTION
* Otherwise, each `Optcarrot::NES.new.run` would leak one Fiber.
  Several people benchmarking Optcarrot used this pattern, to ensure the exact same workload is for each such iteration:
  https://github.com/Shopify/yjit-bench/issues/34
  https://github.com/oracle/truffleruby/issues/959
* Whether unreachable Fibers are terminated is implementation-dependent.
  CRuby 1.9+ does it currently but it is unclear if that is desirable as it must skip `ensure` clauses to preserve that Fibers only switch explicitly and are never run concurrently (https://bugs.ruby-lang.org/issues/595).
  On Ruby implementations which use native threads to emulate Fibers, it is typically not implemented or reliable, as a native thread cannot be terminated without running to the end. And throwing an exception would run `ensure` clause, which violates the fundamental assumption that Fibers of the same Ruby Thread do not execute concurrently.

I noticed that the `while true` loop in `main_loop` does exactly one iteration per frame, so we can simply check a flag there and exit once we're done.