### PR TITLE
Cleanup PPU Fiber in NES#dipose by using the return value of wait_frame

### DIFF
--- a/lib/optcarrot/config.rb
+++ b/lib/optcarrot/config.rb
@@ -102,7 +102,7 @@ module Optcarrot
     # command-line option parser
     class Parser
       def initialize(argv)
-        @argv = argv
+        @argv = argv.dup
         @options = DEFAULT_OPTIONS.dup
         parse_option until @argv.empty?
         error "ROM file is not given" unless @options[:romfile]

--- a/lib/optcarrot/nes.rb
+++ b/lib/optcarrot/nes.rb
@@ -74,6 +74,7 @@ module Optcarrot
       @audio.dispose
       @input.dispose
       @rom.save_battery
+      @ppu.dispose
     end
 
     def run

--- a/lib/optcarrot/ppu.rb
+++ b/lib/optcarrot/ppu.rb
@@ -884,6 +884,11 @@ module Optcarrot
       @hclk_target = (@vclk + @hclk) * RP2C02_CC unless @fiber.resume
     end
 
+    def dispose
+      raise 'PPU Fiber should have finished' unless @fiber.resume(:stop) == :done
+      @fiber = nil
+    end
+
     def wait_frame
       Fiber.yield true
     end
@@ -935,7 +940,7 @@ module Optcarrot
 
       # wait for boot
       boot
-      wait_frame
+      return :done if wait_frame == :stop
 
       while true
         # pre-render scanline
@@ -1251,7 +1256,7 @@ module Optcarrot
 
         # when 684
         vblank_2
-        wait_frame
+        return :done if wait_frame == :stop
       end
     end
     # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Style/SoleNestedConditional


### PR DESCRIPTION
An alternative to https://github.com/mame/optcarrot/pull/35
It is fully equivalent semantically, just a different way to do the check.
It is kind of similar semantically to a Fiber#raise approach but cleaner (no need for an exception, only checks in the needed place) and it works on any Ruby version.