### PR TITLE
Fix sprite collapse with optimization

### DIFF
--- a/lib/optcarrot/ppu.rb
+++ b/lib/optcarrot/ppu.rb
@@ -1422,6 +1422,7 @@ module Optcarrot
 
       # inline method calls
       def ppu_expand_methods(code, mdefs)
+        code = expand_inline_methods(code, :load_extended_sprites, mdefs[:load_extended_sprites])
         code = expand_inline_methods(code, :open_sprite, mdefs[:open_sprite])
 
         # twice is enough


### PR DESCRIPTION
It is caused, because `open_sprite` method call exists after optimized PPU code.

`load_extended_sprites` method uses `open_sprite`, so it is embedded after `open_sprite` is processed.

#27