### PR TITLE
tools/run-benchmark.rb: support recent versions of CRuby.

### DIFF
--- a/tools/run-benchmark.rb
+++ b/tools/run-benchmark.rb
@@ -165,7 +165,7 @@ MASTER_APT = %w(
   libgdbm-dev libdb-dev git ruby
 )
 
-class MasterMJIT < DockerImage
+class MasterRJIT < DockerImage
   FROM = "ubuntu:20.04"
   APT = MASTER_APT
   RUN = [
@@ -174,7 +174,12 @@ class MasterMJIT < DockerImage
     "cd ruby && ./configure --prefix=`pwd`/local",
     "cd ruby && make && make install",
   ]
-  RUBY = "ruby/ruby --jit -Iruby"
+  RUBY = "ruby/ruby --rjit -Iruby"
+end
+
+class Ruby33RJIT < DockerImage
+  FROM = "ruby:3.3-rc"
+  RUBY = "ruby --rjit -Iruby"
 end
 
 class Ruby30MJIT < DockerImage
@@ -193,15 +198,25 @@ class Ruby26MJIT < DockerImage
 end
 
 class MasterYJIT < DockerImage
-  FROM = "ubuntu:20.04"
+  FROM = "rust:latest"
   APT = MASTER_APT
   RUN = [
     "git clone --depth 1 https://github.com/ruby/ruby.git",
-    "cd ruby && autoconf",
+    "cd ruby && ./autogen.sh",
     "cd ruby && ./configure --prefix=`pwd`/local",
     "cd ruby && make && make install",
   ]
   RUBY = "ruby/ruby --yjit -Iruby"
+end
+
+class Ruby33YJIT < DockerImage
+  FROM = "ruby:3.3-rc"
+  RUBY = "ruby --yjit -Iruby"
+end
+
+class Ruby32YJIT < DockerImage
+  FROM = "ruby:3.2"
+  RUBY = "ruby --yjit -Iruby"
 end
 
 class Master < DockerImage
@@ -214,6 +229,14 @@ class Master < DockerImage
     "cd ruby && make && make install",
   ]
   RUBY = "ruby/ruby -Iruby"
+end
+
+class Ruby33 < DockerImage
+  FROM = "ruby:3.3-rc"
+end
+
+class Ruby32 < DockerImage
+  FROM = "ruby:3.2"
 end
 
 class Ruby30 < DockerImage


### PR DESCRIPTION
Hi, mame-san.

This PR aims to add some DockerImage's used in `run-benchmark.rb` for catching up recent release's of CRuby.

- Add Ruby32 and Ruby33 (actually, it means 3.3-rc).
- Add Ruby32YJIT and Ruby33YJIT (actually, it means 3.3-rc).
- Rename MasterMJIT to MasterYJIT because the current master branch of `ruby/ruby` supports only RJIT (and YJIT) instead of MJIT.
- Add Ruby33RJIT (actually, it means 3.3-rc).
- Use base image "rust:latest" for MasterYJIT because current YJIT needs rustc to build.
  In addition, use `./autogen.sh` instead of `autoconf` because `configure` caused an error below in my environment.

```
❯ ruby tools/run-benchmark.rb masteryjit
tools/run-benchmark.rb:2: warning: csv which will be not part of the default gems since Ruby 3.4.0
+------------------+
| build masteryjit |
+------------------+
[+] Building 3.4s (12/14)                                                                                                                                                                                                                                                      
 => [internal] load build definition from Dockerfile.masteryjit                                                                                                                                                                                                           0.0s
 => => transferring dockerfile: 539B                                                                                                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                         0.0s
 => => transferring context: 35B                                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/rust:latest                                                                                                                                                                                                            2.8s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                                                                                                                                               0.0s
 => [1/9] FROM docker.io/library/rust:latest@sha256:911acdfd39276ead0dfb583a833f1db7d787ad0d5333848378d88f19e5fc158c                                                                                                                                                      0.0s
 => [internal] load build context                                                                                                                                                                                                                                         0.0s
 => => transferring context: 22.35kB                                                                                                                                                                                                                                      0.0s
 => CACHED [2/9] WORKDIR /root                                                                                                                                                                                                                                            0.0s
 => CACHED [3/9] RUN apt-get update                                                                                                                                                                                                                                       0.0s
 => CACHED [4/9] RUN apt-get install -y autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev libdb-dev git ruby                                                                              0.0s
 => CACHED [5/9] RUN git clone --depth 1 https://github.com/ruby/ruby.git                                                                                                                                                                                                 0.0s
 => CACHED [6/9] RUN cd ruby && autoconf                                                                                                                                                                                                                                  0.0s
 => ERROR [7/9] RUN cd ruby && ./configure --prefix=`pwd`/local                                                                                                                                                                                                           0.5s
------                                                                                                                                                                                                                                                                         
 > [7/9] RUN cd ruby && ./configure --prefix=`pwd`/local:
#11 0.486 configure: error: cannot find required auxiliary files: config.guess config.sub
------
executor failed running [/bin/sh -c cd ruby && ./configure --prefix=`pwd`/local]: exit code: 1
tools/run-benchmark.rb:80:in `build': unhandled exception
        from tools/run-benchmark.rb:417:in `block in run_benchmark'
        from tools/run-benchmark.rb:443:in `block in each_target_image'
        from tools/run-benchmark.rb:441:in `each'
        from tools/run-benchmark.rb:441:in `each_target_image'
        from tools/run-benchmark.rb:415:in `run_benchmark'
        from tools/run-benchmark.rb:407:in `main'
        from tools/run-benchmark.rb:534:in `<main>'
```

