### PR TITLE
Specify the aspect ratio 1:1 for sixel video driver

### DIFF
--- a/lib/optcarrot/driver/sixel_video.rb
+++ b/lib/optcarrot/driver/sixel_video.rb
@@ -7,7 +7,7 @@ module Optcarrot
       super
       @buff = "".b
       @line = "".b
-      @seq_setup = "\e[H\ePq"
+      @seq_setup = "\e[H\eP7q"
       print "\e[2J"
 
       @palette, colors = Driver.quantize_colors(@palette_rgb)


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0b7562e9-81ce-4a97-9922-c4f6e6a3dcca)

After:
![image](https://github.com/user-attachments/assets/b5fbeb9d-b7ed-440e-8dd2-535a14df2d46)
