### PR TITLE
Use TruffleRuby on Oracle GraalVM as it is faster

### DIFF
--- a/tools/run-benchmark.rb
+++ b/tools/run-benchmark.rb
@@ -272,9 +272,9 @@ class Ruby187 < DockerImage
 end
 
 class TruffleRuby < DockerImage
-  URL = "https://github.com/truffleruby/truffleruby/releases/download/graal-34.0.1/truffleruby-community-jvm-34.0.1-linux-amd64.tar.gz"
+  URL = "https://github.com/truffleruby/truffleruby/releases/download/graal-34.0.1/truffleruby-jvm-34.0.1-linux-amd64.tar.gz"
   FROM = "buildpack-deps:26.04"
-  RUBY = "truffleruby-community-jvm-*/bin/ruby"
+  RUBY = "truffleruby-jvm-*/bin/ruby"
   SUPPORTED_MODE = %w(default)
 end
 


### PR DESCRIPTION
* As recommended in https://github.com/truffleruby/truffleruby/blob/master/doc/user/installing-truffleruby.md and https://github.com/truffleruby/truffleruby/blob/master/doc/user/benchmarking.md