### PR TITLE
tools/run-benchmark.rb: take an argument for -h

### DIFF
--- a/tools/run-benchmark.rb
+++ b/tools/run-benchmark.rb
@@ -364,7 +364,7 @@ class CLI
     o.on("-c NUM", Integer, "iteration count") {|v| @count = v }
     o.on("-r FILE", String, "rom file") {|v| @romfile = v }
     o.on("-f FRAME", Integer, "target frame") {|v| @target_frame = v }
-    o.on("-h", Integer, "fps history mode") {|v| @history = v }
+    o.on("-h NUM", Integer, "fps history mode") {|v| @history = v }
     o.separator("")
     o.separator("Examples:")
     latest = DockerImage::IMAGES.find {|n| !n.tag.start_with?("master") && !n.tag.include?("mjit") }.tag


### PR DESCRIPTION
The original spec `o.on("-h", Integer, ...)` parses as a no-argument switch (a bare class such as Integer in `OptionParser#on` does not by itself request an argument), so `-h 30` left '30' as a positional and `@history` stayed nil.

With `@history` nil, `--print-fps-history` was never appended to the benchmark options, and the fps-history bookkeeping (`fps_history << nil until fps_history.size == @history + 1`) would also have crashed on `nil + 1` had it been reached.

Repro before this commit:

```
  $ ruby tools/run-benchmark.rb truffleruby -c 1 -f 30 -h 30
  tools/run-benchmark.rb:439:in 'CLI#run_test':
    you must specify one tag or test-run (RuntimeError)
```

Make `-h` take a NUM argument explicitly so the value reaches `@history`.